### PR TITLE
Change documentation to reflect defaults change

### DIFF
--- a/files/www/lan/settings.js
+++ b/files/www/lan/settings.js
@@ -100,7 +100,7 @@ function appendSetting(p, path, value, mode)
 		break;
 	case "publish_map":
 		b = append_radio(p, "Zur Karte beitragen", id, value, [["Nichts", "none"], ["Wenig", "basic"], ["Mehr", "more"], ["Alles", "all"]]);
-		addHelpText(b, "Mit wievielen Daten soll dieser Knoten zur Knotenkarte beitragen? (Wenig: Name/Version/Position/Kontakt, Mehr: +Modell/+Uptime/+CPU-Auslastung, Alles: +Speicherauslastung/+IP-Adressen des Routers im Freifunk-Netz)");
+		addHelpText(b, "Mit wievielen Daten soll dieser Knoten zur Knotenkarte beitragen? (Wenig: Name/Version/Modell/Position/Kontakt, Mehr: +Uptime/+CPU-Auslastung, Alles: +Speicherauslastung/+IP-Adressen des Routers im Freifunk-Netz)");
 		break;
 	case "limit_egress":
 		b = append_input(p, "Freifunk Upload", id, value);


### PR DESCRIPTION
Router model will be transmitted to map since commit 7dd48e51b96b3c9d65db7c98b12aba592c098447 as a default.